### PR TITLE
Tweak for compatible layer

### DIFF
--- a/fluent-plugin-key-picker.gemspec
+++ b/fluent-plugin-key-picker.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'rake', '~> 0'
-  gem.add_development_dependency 'fluentd', '~> 0'
+  gem.add_development_dependency 'test-unit', '~> 3.2.0'
+  gem.add_dependency 'fluentd', '>= 0.12.0'
 end

--- a/lib/fluent/plugin/out_key_picker.rb
+++ b/lib/fluent/plugin/out_key_picker.rb
@@ -40,7 +40,7 @@ module Fluent
       es.each {|time,record|
         t = tag.dup
         filter_record(t, time, record)
-        Engine.emit(t, time, record)
+        router.emit(t, time, record)
       }
       chain.next
     end

--- a/test/plugin/test_out_key_picker.rb
+++ b/test/plugin/test_out_key_picker.rb
@@ -1,6 +1,9 @@
-require 'byebug'
 # -*- encoding: utf-8 -*-
-require '../test_helper'
+begin
+  require 'byebug'
+rescue LoadError
+end
+require_relative '../test_helper'
 
 class KeyPickerOutputTest < Test::Unit::TestCase
 


### PR DESCRIPTION
I think that this plugin should work with Fluentd v0.14 on compatible layer.
This plugin does not depends on test-unit for development.
And the biggest issue is using `Engine.emit`.
It causes raising exception at runtime because Fluentd v0.14 treats it as a bug.