### PR TITLE
Add Filter version of key_picker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,52 @@
 # fluent-plugin-key-picker, a plugin for [Fluentd](http://fluentd.org)
 
 ## Component
-KeyPickerOutput
+
+* KeyPickerFilter
+* KeyPickerOutput
 
 Take a record and pick only the keys you want to pass
 
-## wat?!
+## KeyPickerFilter
+
+### wat?!
+
+```
+<filter test.**>
+  type key_picker
+  keys           foo, baz
+</filter>
+```
+
+And you feed such a value into fluentd:
+
+```
+"test" => {
+  "foo" => "a",
+  "bar" => "b",
+  "baz" => "c",
+  "bah" => "e",
+}
+```
+
+Then you'll get filtered tags/records like so:
+
+```
+"picked.test" => {
+  "foo" => "a",
+  "baz" => "c"
+}
+```
+
+### Configuration
+
+#### keys
+
+`keys` should include the keys you want to pick.
+
+## KeyPickerOutput
+
+### wat?!
 
 ```
 <match test.**>
@@ -35,18 +76,17 @@ Then you'll get re-emmited tags/records like so:
 }
 ```
 
-## Configuration
+### Configuration
 
-### keys
+#### keys
 
 `keys` should include the keys you want to pick.
 
-### remove_tag_prefix, remove_tag_suffix, add_tag_prefix, add_tag_suffix
+#### remove_tag_prefix, remove_tag_suffix, add_tag_prefix, add_tag_suffix
 
 These params are included from `Fluent::HandleTagNameMixin`. See the code for details.
 
 You must add at least one of these params.
-
 
 ## Installation
 

--- a/lib/fluent/plugin/filter_key_picker.rb
+++ b/lib/fluent/plugin/filter_key_picker.rb
@@ -1,0 +1,34 @@
+# coding: utf-8
+require 'fluent/plugin/key_picker_support'
+
+module Fluent
+  class KeyPickerFilter < Filter
+    include Fluent::KeyPickerSupport
+
+    Fluent::Plugin.register_filter('key_picker', self)
+
+    config_param :keys, :string, :default => nil
+
+    def configure(conf)
+      super
+
+      unless keys && keys.length > 1
+        raise ConfigError, "keys: You need to specify the keys you want to pick."
+      end
+
+      @keys = keys && keys.split(/\s*,\s*/)
+    end
+
+    def start
+      super
+    end
+
+    def shutdown
+      super
+    end
+
+    def filter(tag, time, record)
+      pick_key(record, self)
+    end
+  end
+end

--- a/lib/fluent/plugin/key_picker_support.rb
+++ b/lib/fluent/plugin/key_picker_support.rb
@@ -1,0 +1,11 @@
+module Fluent
+  module KeyPickerSupport
+    def pick_key(record, plugin)
+      begin
+        return record.keep_if{|key, value| @keys.include?(key.to_s)}
+      rescue ArgumentError => error
+        plugin.log.warn("out_key_picker: #{error.message}")
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/out_key_picker.rb
+++ b/lib/fluent/plugin/out_key_picker.rb
@@ -1,8 +1,10 @@
 # coding: utf-8
+require 'fluent/plugin/key_picker_support'
 
 module Fluent
   class KeyPickerOutput < Output
     include Fluent::HandleTagNameMixin
+    include Fluent::KeyPickerSupport
 
     Fluent::Plugin.register_output('key_picker', self)
 
@@ -46,11 +48,7 @@ module Fluent
     end
 
     def filter_record(tag, time, record)
-      begin
-        record.keep_if{|key, value| @keys.include?(key.to_s)}
-      rescue ArgumentError => error
-        $log.warn("out_key_picker: #{error.message}")
-      end
+      record = pick_key(record, self)
       super(tag, time, record)
     end
   end

--- a/test/plugin/test_filter_key_picker.rb
+++ b/test/plugin/test_filter_key_picker.rb
@@ -1,0 +1,100 @@
+# -*- encoding: utf-8 -*-
+begin
+  require 'byebug'
+rescue LoadError
+end
+require_relative '../test_helper'
+
+class KeyPickerFilterTest < Test::Unit::TestCase
+
+  TEST_RECORD = {'foo' => 'a', 'bar' => 'b', 'baz' => 'c'}
+  EMPTY_HASH = {}
+
+  def setup
+    Fluent::Test.setup
+  end
+
+  def create_driver(conf, tag = 'test')
+    Fluent::Test::FilterTestDriver.new(
+      Fluent::KeyPickerFilter, tag
+    ).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver(%[
+      keys           foo, bar
+    ])
+    assert_equal ['foo', 'bar'], d.instance.keys
+
+    #No Keys
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[
+      ])
+    end
+
+    #0 length keys
+    assert_raise(Fluent::ConfigError) do
+      create_driver(%[
+        keys
+      ])
+    end
+  end
+
+  def test_no_matching_record
+    d = create_driver(%[
+      keys           foo, bar
+    ])
+
+    tag    = 'test'
+    record = {}
+
+    assert_equal record, {}
+  end
+
+  def test_emit
+    d = create_driver(%[
+      keys           foo, bar
+    ])
+
+    d.run { d.emit(TEST_RECORD.dup) }
+    emits = d.filtered_as_array
+
+    assert_equal 1, emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal 'a', emits[0][2]['foo']
+    assert_equal 'b', emits[0][2]['bar']
+  end
+
+  def test_emit_multi
+    d = create_driver(%[
+      keys           foo, bar
+    ])
+    d.run do
+      d.emit(TEST_RECORD.dup)
+      d.emit(TEST_RECORD.dup)
+      d.emit(TEST_RECORD.dup)
+    end
+    emits = d.filtered_as_array
+
+    assert_equal 3, emits.count
+
+    emits.each do |e|
+      assert_equal 'test', e[0]
+      assert_equal 'a', e[2]['foo']
+      assert_equal 'b', e[2]['bar']
+    end
+  end
+
+  def test_emit_without_match_key
+    d = create_driver(%[
+      keys           fiz, faz
+    ])
+    d.run { d.emit(TEST_RECORD.dup) }
+    emits = d.filtered_as_array
+
+    assert_equal 1, emits.count
+    assert_equal 'test', emits[0][0]
+    assert_equal EMPTY_HASH, emits[0][2]
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_key_picker'
+require 'fluent/plugin/filter_key_picker'
 
 class Test::Unit::TestCase
 end


### PR DESCRIPTION
Please review after #1 is merged.

---

It would be nice to provide filter version of key_picker.
Because this plugin feature can be implemented in filter plugin mechanism and filter plugin can migrate to use v0.14 API more easily than non-buffered output plugin.